### PR TITLE
Fixing a bug in task edit page

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ def post(post_id):
 def edit(post_id):
     if 'loggedin' in session:
         conn = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
-        conn.execute("SELECT title, message, status, assigned, level, deadline FROM posts WHERE id = %s", (post_id,))
+        conn.execute("SELECT title, message, status, assigned, level, deadline, project FROM posts WHERE id = %s", (post_id,))
         old_data = conn.fetchone()
 
         if request.method == "POST":
@@ -104,9 +104,10 @@ def edit(post_id):
             assigned = request.form['assigned']
             level = request.form['level']
             deadline = request.form['date']
+            assigned_project = request.form['assigned_project']
             conn.execute(
-                f"UPDATE posts SET title = %s, message = %s, status = %s, assigned = %s, level = %s, deadline=%s WHERE id = {post_id}",
-                (title, message, status, assigned, level, deadline))
+                f"UPDATE posts SET title = %s, message = %s, status = %s, assigned = %s, level = %s, deadline = %s, project = %s WHERE id = {post_id}",
+                (title, message, status, assigned, level, deadline, assigned_project))
             conn.connection.commit()
             conn.close()
             return redirect(url_for('index'))

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -31,7 +31,7 @@
                 <option value="Urgent">Urgent</option>
         </select><br>
         <select class="feedback-input" name="assigned_project" id="assigned_project">
-                <option value="Single Task">Single Task</option>
+                <option value="{{old_data['project']}}">{{old_data['project']}}</option>
                 {% for project_title in project_titles %}
                     <option value="{{ project_title.title }}">{{ project_title.title }}</option>
                 {% endfor %}


### PR DESCRIPTION
When a user wanted to edit a ticket, the user wasn't able to set a new project to which is the ticket attached.
